### PR TITLE
feat(#2): select multiple entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "clippy",
   "productName": "Clippy",
   "version": "1.0.0",
-  "description": "My Electron application description",
+  "description": "Clippy is a minimal clipboard history log made with Electron.js!",
   "main": "src/index.js",
   "scripts": {
     "dev": "electron-forge start",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,7 @@
 module.exports = {
   CLIPBOARD_EVENT: "clipboard-change",
   CLIPBOARD_CLEAR: "clipboard-clear",
+  CLIPBOARD_BULK_COPY: "clipboard-bulk-copy",
   MESSAGE_CLEAR_BACKEND:
     "Do you wish to clear your current system clipboard as well? Note that choosing 'No' or 'Cancel' will keep the first entry as is since it's synced with your system's clipboard.",
   MESSAGE_CONFIRM_REMOVE:

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,14 @@ body {
   padding-left: 0;
 }
 
+#container > ul[data-selecting="true"] * {
+  user-select: none;
+  -khtml-user-select: none;
+  -o-user-select: none;
+  -moz-user-select: -moz-none;
+  -webkit-user-select: none;
+}
+
 #container > ul > li {
   display: block;
   list-style: none;
@@ -28,10 +36,15 @@ body {
   max-width: 100%;
   border: solid 1px rgba(0, 0, 0, 0.5);
   border-radius: 5px;
+  transition: border 0.5s;
 }
 
 #container > ul > li * {
   max-width: 100%;
+}
+
+#container > ul > li[data-selected="true"] {
+  border: dashed 1px blue;
 }
 
 #container > ul > li > button.pin {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,11 @@ const {
 const { nanoid } = require("nanoid");
 
 const Entry = require("./types/Entry");
-const { CLIPBOARD_EVENT, CLIPBOARD_CLEAR } = require("./constants");
+const {
+  CLIPBOARD_EVENT,
+  CLIPBOARD_CLEAR,
+  CLIPBOARD_BULK_COPY,
+} = require("./constants");
 
 app.setLoginItemSettings({
   openAtLogin: true,
@@ -115,6 +119,10 @@ const handleIPCCopy = (ev, { type, value }) => {
   else clipboard.writeText(value);
 };
 
+const handleIPCBulk = (ev, value) => {
+  clipboard.writeText(value);
+};
+
 const externalLinkHandler = (e, url) => {
   e.preventDefault();
 
@@ -139,6 +147,7 @@ const preventNavigation = (e) => {
 
 ipcMain.handle(CLIPBOARD_CLEAR, clear);
 ipcMain.on(CLIPBOARD_EVENT, handleIPCCopy);
+ipcMain.on(CLIPBOARD_BULK_COPY, handleIPCBulk);
 
 const createWindow = () => {
   try {

--- a/src/render.js
+++ b/src/render.js
@@ -1,9 +1,3 @@
-/**
- * @typedef {Object} State
- * @property {Entry[]} State.history
- */
-
-/** */
 const { ipcRenderer } = require("electron");
 
 const Preact = require("preact");
@@ -17,6 +11,7 @@ const {
   MESSAGE_CONFIRM_REMOVE,
   CLIPBOARD_CLEAR,
   CLIPBOARD_EVENT,
+  CLIPBOARD_BULK_COPY,
 } = require("./constants");
 
 const html = htm.bind(Preact.h);
@@ -34,8 +29,17 @@ function linkify(text, click) {
   });
 }
 
+/**
+ *
+ * @param {Object} param0
+ * @param {Entry} param0.entry
+ * @param {Function} param0.pin
+ * @param {Function} param0.copy
+ * @param {Function} param0.remove
+ */
 const ListEntry = ({ entry, pin, copy, remove }) => html`<li
   data-_id=${entry._id}
+  data-selected=${entry.selected}
   style="position: relative; list-style: none;"
   title="Click to copy"
   onClick=${copy}
@@ -61,11 +65,55 @@ const ListEntry = ({ entry, pin, copy, remove }) => html`<li
 class App extends Preact.Component {
   constructor(props) {
     super(props);
-    /** @type {State} */
-    this.state = { history: [] };
+    this.state = {
+      /** @type {Entry[]} */
+      history: [],
+      selecting: false,
+    };
   }
 
+  handleKeyDownShift = ({ code }) => {
+    document.addEventListener("keyup", this.handleKeyUpShift);
+
+    if (/Shift/gi.test(code)) {
+      this.setState({
+        ...this.state,
+        selecting: true,
+      });
+    }
+  };
+
+  handleKeyUpShift = ({ code }) => {
+    document.removeEventListener("keyup", this.handleKeyUpShift);
+    document.addEventListener("click", this.handleKeyUpClick);
+
+    if (/Shift/gi.test(code) && !this.state.history.some((e) => e.selected)) {
+      this.setState({
+        ...this.state,
+        selecting: false,
+      });
+    }
+  };
+
+  handleKeyUpClick = () => {
+    this.setState({
+      ...this.state,
+      history: this.state.history.map(
+        (entry) =>
+          new Entry({
+            ...entry,
+            selected: false,
+          })
+      ),
+      selecting: false,
+    });
+
+    document.removeEventListener("click", this.handleKeyUpClick);
+  };
+
   componentDidMount() {
+    document.addEventListener("keydown", this.handleKeyDownShift);
+
     ipcRenderer.on(CLIPBOARD_EVENT, (ev, entry) => {
       // Entry here is gonna be a simple javascript object because electron
       // serialises IPC messages, so I convert it back
@@ -75,13 +123,17 @@ class App extends Preact.Component {
       // switch `history` to an object instead, O(1) search by id
       if (!history.some((e) => e.compareTo(entry)))
         this.setState({
+          ...this.state,
           history: [...history, new Entry(entry)],
         });
     });
   }
 
   clearHistory = () => {
-    this.setState({ history: this.state.history.filter((e) => !e.pinned) });
+    this.setState({
+      ...this.state,
+      history: this.state.history.filter((e) => !e.pinned),
+    });
 
     if (confirm(MESSAGE_CLEAR_BACKEND)) this.clearClipboard();
   };
@@ -102,6 +154,7 @@ class App extends Preact.Component {
     // Leaving the user confused is not part of the deal.
     if (confirm(MESSAGE_CONFIRM_REMOVE)) {
       this.setState({
+        ...this.state,
         history: this.state.history.filter((entry) => entry._id !== _id),
       });
     }
@@ -111,14 +164,31 @@ class App extends Preact.Component {
    * @param {UIEvent} e
    */
   copy = (e) => {
+    e.preventDefault();
     const { target, currentTarget } = e;
 
     // Make sure to not copy links and leave their handling to the backend
     if (target.tagName.toLowerCase() !== "a") {
       const { _id } = currentTarget.dataset;
-      const entry = this.state.history.find((e) => e._id === _id);
+      const indexOfEntry = this.state.history.findIndex((e) => e._id === _id);
 
-      ipcRenderer.send(CLIPBOARD_EVENT, entry);
+      if (!this.state.selecting)
+        ipcRenderer.send(CLIPBOARD_EVENT, this.state.history[indexOfEntry]);
+      else {
+        const history = Array.from(this.state.history);
+
+        if (history[indexOfEntry].type !== "text") {
+          alert("Fatal: Can only bulk copy text entries");
+          return;
+        }
+
+        history[indexOfEntry].selected = !history[indexOfEntry].selected;
+
+        this.setState({
+          ...this.state,
+          history,
+        });
+      }
     }
 
     e.stopPropagation();
@@ -136,20 +206,34 @@ class App extends Preact.Component {
     history[indexOfEntry].pinned = !history[indexOfEntry].pinned;
 
     this.setState({
-      history: history,
+      ...this.history,
+      history,
     });
 
     e.stopPropagation();
   };
 
+  copySelection = (e) => {
+    e.preventDefault();
+    const merged = this.state.history.filter((e) => e.selected).join("\r\n");
+
+    ipcRenderer.send(CLIPBOARD_BULK_COPY, merged);
+  };
+
   render(props, state) {
+    const enableCopySelection =
+      this.state.selecting && this.state.history.some((e) => e.selected);
+
     return html`
       <div style="display: flex">
         <button onClick=${this.clearHistory}>Clear log</button>
         <button onClick=${this.clearClipboard}>Clear clipboard only</button>
+        <button onClick=${this.copySelection} disabled=${!enableCopySelection}>
+          Copy selection
+        </button>
       </div>
       ${state.history.length == 0 && "Free as the wind~"}
-      <ul>
+      <ul data-selecting=${this.state.selecting}>
         ${Array.from(state.history)
           .filter((e) => e.pinned)
           .reverse()

--- a/src/types/entry.js
+++ b/src/types/entry.js
@@ -1,5 +1,5 @@
 const TYPES = ["image", "text"];
-const EXCLUDED = ["pinned", "_id"]; // excluded from comparison
+const EXCLUDED = ["pinned", "_id", "selected"]; // excluded from comparison
 
 module.exports = class Entry {
   value = "";
@@ -7,15 +7,28 @@ module.exports = class Entry {
   type = ""; // Interpretted type
   _type = ""; // This is original MIME type
   pinned = false;
+  selected = false;
 
-  constructor({ type, _type, value, _id = null, pinned = false }) {
+  constructor({
+    type,
+    _type,
+    value,
+    _id = null,
+    pinned = false,
+    selected = false,
+  }) {
     if (!TYPES.includes(type)) throw new Error(`Type must be one of ${TYPES}`);
 
     this.value = value;
     this.type = type;
     this.pinned = pinned;
+    this.selected = selected;
     this._type = _type;
     this._id = _id;
+  }
+
+  toString() {
+    return this.value;
   }
 
   compareTo(obj2) {


### PR DESCRIPTION
Implementation complete for mouse-based navigation. 
- Can select multiple entries
- Entries must be of type `text` only
- Added together using `\r\n` before copying to clipboard