### PR TITLE
fix: Multi select dialog propagation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -953,6 +953,25 @@
         "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.12.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.15.tgz",
+      "integrity": "sha512-OwptMSRnRWJo+tJ9v9wgAf72ydXWfYSXWhnQjZing8nGZSDFqU1MBleKM3+DriKkcbv7RagA8gVeB0A1PNlNow==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.12.13",
+        "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz",

--- a/src/render.js
+++ b/src/render.js
@@ -175,22 +175,20 @@ class App extends Preact.Component {
       const { _id } = currentTarget.dataset;
       const indexOfEntry = this.state.history.findIndex((e) => e._id === _id);
 
-      if (!this.state.selecting)
+      if (!this.state.selecting){
         ipcRenderer.send(CLIPBOARD_EVENT, this.state.history[indexOfEntry]);
-      else {
+      }else {
         const history = Array.from(this.state.history);
 
         if (history[indexOfEntry].type !== "text") {
           alert("Fatal: Can only bulk copy text entries");
-          return;
+        }else{
+          history[indexOfEntry].selected = !history[indexOfEntry].selected;
+          this.setState({
+            ...this.state,
+            history,
+          });
         }
-
-        history[indexOfEntry].selected = !history[indexOfEntry].selected;
-
-        this.setState({
-          ...this.state,
-          history,
-        });
       }
     }
 


### PR DESCRIPTION
# Description

Fix #29 by stopping the handleKeyUpClick from running after the alert.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Test Configuration**:
* Operating System: Windows 10 Pro, build 19042.746

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules